### PR TITLE
fix: remove static superflous static casts

### DIFF
--- a/inc/finalmq/protocols/mqtt5/Mqtt5Protocol.h
+++ b/inc/finalmq/protocols/mqtt5/Mqtt5Protocol.h
@@ -25,6 +25,7 @@
 #include "finalmq/streamconnection/IMessage.h"
 #include "finalmq/protocols/mqtt5/Mqtt5CommandData.h"
 #include "finalmq/streamconnection/StreamConnection.h"
+#include "Mqtt5Serialization.h"
 
 #include <deque>
 #include <functional>
@@ -95,17 +96,17 @@ public:
     unsigned int getPacketId();
     void resendMessages(const IStreamConnectionPtr& connection);
     void sendPendingMessages(const IStreamConnectionPtr& connection);
-    void prepareForSendWithPacketId(const IMessagePtr& message, std::uint8_t* bufferPacketId, unsigned qos, unsigned int command, unsigned int packetId);
-    bool prepareForSend(const IMessagePtr& message, std::uint8_t* bufferPacketId, unsigned qos, unsigned int command);
-    bool handleAck(const IStreamConnectionPtr& connection, unsigned int command, unsigned int packetId, unsigned int reasoncode);
+    void prepareForSendWithPacketId(const IMessagePtr& message, std::uint8_t* bufferPacketId, unsigned qos, Mqtt5Command command, unsigned int packetId);
+    bool prepareForSend(const IMessagePtr& message, std::uint8_t* bufferPacketId, unsigned qos, Mqtt5Command command);
+    bool handleAck(const IStreamConnectionPtr& connection, Mqtt5Command command, unsigned int packetId, unsigned int reasoncode);
     void sendPubAck(const IStreamConnectionPtr& connection, const Mqtt5PubAckData& data);
     void sendPubRec(const IStreamConnectionPtr& connection, const Mqtt5PubAckData& data);
     void sendPubRel(const IStreamConnectionPtr& connection, const Mqtt5PubAckData& data, const IMessagePtr& message);
     void sendPubComp(const IStreamConnectionPtr& connection, const Mqtt5PubAckData& data);
     void sendSubAck(const IStreamConnectionPtr& connection, const Mqtt5SubAckData& data);
     void sendUnsubAck(const IStreamConnectionPtr& connection, const Mqtt5SubAckData& data);
-    void sendPubAck(const IStreamConnectionPtr& connection, unsigned int command, const Mqtt5PubAckData& data);
-    void sendSubAck(const IStreamConnectionPtr& connection, unsigned int command, const Mqtt5SubAckData& data);
+    void sendPubAck(const IStreamConnectionPtr& connection, Mqtt5Command command, const Mqtt5PubAckData& data);
+    void sendSubAck(const IStreamConnectionPtr& connection, Mqtt5Command command, const Mqtt5SubAckData& data);
 
 
     // IMqtt5Protocol
@@ -137,7 +138,7 @@ public:
         IMessagePtr     message;
         std::uint8_t*   bufferPacketId = nullptr;
         unsigned int    qos = 0;
-        unsigned int    command = 0;
+        Mqtt5Command    command {};
     };
     struct MessageStatus
     {

--- a/inc/finalmq/protocols/mqtt5/Mqtt5Serialization.h
+++ b/inc/finalmq/protocols/mqtt5/Mqtt5Serialization.h
@@ -28,7 +28,7 @@
 namespace finalmq {
 
 
-enum Mqtt5Command
+enum class Mqtt5Command
 {
     COMMAND_CONNECT         = 1,       // Server <-  Client, Connection request
     COMMAND_CONNACK         = 2,       // Server  -> Client, Connect acknowledgment
@@ -53,7 +53,7 @@ class Mqtt5Serialization
 {
 public:
     Mqtt5Serialization(char* buffer, unsigned int sizeBuffer, unsigned int indexBuffer);
-    int getReadIndex() const;
+    unsigned int getReadIndex() const;
 
     bool deserializeConnect(Mqtt5ConnectData& data);
     bool deserializeConnAck(Mqtt5ConnAckData& data);

--- a/src/protocols/mqtt5/Mqtt5Protocol.cpp
+++ b/src/protocols/mqtt5/Mqtt5Protocol.cpp
@@ -194,24 +194,23 @@ bool Mqtt5Protocol::receivePayload(const IStreamConnectionPtr& connection, const
 
 
 
-bool Mqtt5Protocol::handleAck(const IStreamConnectionPtr& connection, unsigned int command, unsigned int packetId, unsigned int reasoncode)
+bool Mqtt5Protocol::handleAck(const IStreamConnectionPtr& connection, Mqtt5Command command, unsigned int packetId, unsigned int reasoncode)
 {
     bool ok = true;
     std::unique_lock<std::mutex> lock(m_mutex);
     if ((packetId != 0) && (packetId < m_messageIdsAllocated.size()))
     {
-        Mqtt5Command cmd = static_cast<Mqtt5Command>(command);
         MessageStatus& status = m_messageIdsAllocated[packetId];
-        if (((status.status == MessageStatus::SENDSTAT_WAITPUBACK)   && (cmd == Mqtt5Command::COMMAND_PUBACK))  ||
-            ((status.status == MessageStatus::SENDSTAT_WAITPUBREC)   && (cmd == Mqtt5Command::COMMAND_PUBREC))  ||
-            ((status.status == MessageStatus::SENDSTAT_WAITPUBCOMP)  && (cmd == Mqtt5Command::COMMAND_PUBCOMP)) ||
-            ((status.status == MessageStatus::SENDSTAT_WAITSUBACK)   && (cmd == Mqtt5Command::COMMAND_SUBACK))  ||
-            ((status.status == MessageStatus::SENDSTAT_WAITUNSUBACK) && (cmd == Mqtt5Command::COMMAND_UNSUBACK)))
+        if (((status.status == MessageStatus::SENDSTAT_WAITPUBACK)   && (command == Mqtt5Command::COMMAND_PUBACK))  ||
+            ((status.status == MessageStatus::SENDSTAT_WAITPUBREC)   && (command == Mqtt5Command::COMMAND_PUBREC))  ||
+            ((status.status == MessageStatus::SENDSTAT_WAITPUBCOMP)  && (command == Mqtt5Command::COMMAND_PUBCOMP)) ||
+            ((status.status == MessageStatus::SENDSTAT_WAITSUBACK)   && (command == Mqtt5Command::COMMAND_SUBACK))  ||
+            ((status.status == MessageStatus::SENDSTAT_WAITUNSUBACK) && (command == Mqtt5Command::COMMAND_UNSUBACK)))
         {
             assert(status.iterator != m_messagesWaitAck.end());
             m_messagesWaitAck.erase(status.iterator);
             status.iterator = m_messagesWaitAck.end();
-            if ((cmd != Mqtt5Command::COMMAND_PUBREC) || (reasoncode >= 128))
+            if ((command != Mqtt5Command::COMMAND_PUBREC) || (reasoncode >= 128))
             {
                 status.status = MessageStatus::SENDSTAT_NONE;
                 // if last entry is freed ...
@@ -246,9 +245,6 @@ bool Mqtt5Protocol::handleAck(const IStreamConnectionPtr& connection, unsigned i
     }
     return ok;
 }
-
-
-
 
 bool Mqtt5Protocol::processPayload(const IStreamConnectionPtr& connection)
 {
@@ -623,7 +619,7 @@ static void putPacketIdIntoMessage(std::uint8_t* bufferPacketId, unsigned int pa
 }
 
 
-void Mqtt5Protocol::prepareForSendWithPacketId(const IMessagePtr& message, std::uint8_t* bufferPacketId, unsigned qos, unsigned int command, unsigned int packetId)
+void Mqtt5Protocol::prepareForSendWithPacketId(const IMessagePtr& message, std::uint8_t* bufferPacketId, unsigned qos, Mqtt5Command command, unsigned int packetId)
 {
     assert(bufferPacketId != nullptr);
     assert(packetId < m_messageIdsAllocated.size());
@@ -632,8 +628,7 @@ void Mqtt5Protocol::prepareForSendWithPacketId(const IMessagePtr& message, std::
     MessageStatus::Status status = MessageStatus::SENDSTAT_NONE;
     if (qos == 1)
     {
-        Mqtt5Command cmd = static_cast<Mqtt5Command>(command);
-        switch (cmd)
+        switch (command)
         {
         case Mqtt5Command::COMMAND_PUBLISH:
             status = MessageStatus::SENDSTAT_WAITPUBACK;
@@ -680,7 +675,7 @@ unsigned int Mqtt5Protocol::getPacketId()
 }
 
 
-bool Mqtt5Protocol::prepareForSend(const IMessagePtr& message, std::uint8_t* bufferPacketId, unsigned qos, unsigned int command)
+bool Mqtt5Protocol::prepareForSend(const IMessagePtr& message, std::uint8_t* bufferPacketId, unsigned qos, Mqtt5Command command)
 {
     // qos == 0 -> these messages will not be treated with ack and flow control
     // messages will get lost when the connection is (temporarly) gone.
@@ -731,7 +726,7 @@ void Mqtt5Protocol::sendPublish(const IStreamConnectionPtr& connection, Mqtt5Pub
 }
 
 
-void Mqtt5Protocol::sendPubAck(const IStreamConnectionPtr& connection, unsigned int command, const Mqtt5PubAckData& data)
+void Mqtt5Protocol::sendPubAck(const IStreamConnectionPtr& connection, Mqtt5Command command, const Mqtt5PubAckData& data)
 {
     unsigned int sizePropPayload = 0;
     unsigned int sizePayload = Mqtt5Serialization::sizePubAck(data, sizePropPayload);
@@ -739,7 +734,7 @@ void Mqtt5Protocol::sendPubAck(const IStreamConnectionPtr& connection, unsigned 
     IMessagePtr message = std::make_shared<ProtocolMessage>(0);
     char* buffer = message->addSendHeader(sizeMessage);
     Mqtt5Serialization serialization(buffer, sizeMessage, 0);
-    serialization.serializePubAck(data, static_cast<Mqtt5Command>(command), sizePayload, sizePropPayload);
+    serialization.serializePubAck(data, command, sizePayload, sizePropPayload);
 
     if (connection)
     {
@@ -801,7 +796,7 @@ void Mqtt5Protocol::sendSubscribe(const IStreamConnectionPtr& connection, const 
     }
 }
 
-void Mqtt5Protocol::sendSubAck(const IStreamConnectionPtr& connection, unsigned int command, const Mqtt5SubAckData& data)
+void Mqtt5Protocol::sendSubAck(const IStreamConnectionPtr& connection, Mqtt5Command command, const Mqtt5SubAckData& data)
 {
     unsigned int sizePropPayload = 0;
     unsigned int sizePayload = Mqtt5Serialization::sizeSubAck(data, sizePropPayload);

--- a/src/protocols/mqtt5/Mqtt5Serialization.cpp
+++ b/src/protocols/mqtt5/Mqtt5Serialization.cpp
@@ -64,8 +64,7 @@ Mqtt5Serialization::Mqtt5Serialization(char* buffer, unsigned int sizeBuffer, un
 
 }
 
-
-int Mqtt5Serialization::getReadIndex() const
+unsigned int Mqtt5Serialization::getReadIndex() const
 {
     return m_indexBuffer;
 }


### PR DESCRIPTION
Please take a look. 
Removed unnecessary casts in mqtt protocol. 
